### PR TITLE
feat: Change name and add missing fields into the manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "js-profile-visualizer",
+  "version": "0.0.21",
+  "publisher": "ms-vscode",
   "private": true,
   "scripts": {
     "postinstall": "lerna bootstrap --force-local",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-profile-visualizer",
+  "name": "vscode-js-profile-table",
   "version": "0.0.21",
   "publisher": "ms-vscode",
   "private": true,


### PR DESCRIPTION
The publisher and the version are missing, so I offer to add them.

The name in the manifest is not the same as in the marketplace or even the vscode product.json. So I thought changing to the one used in the two latter case would be a good idea.

I you want me to remove the rename commit, tell me and I do.