### PR TITLE
Follow-Up to #73: Remove Obsolete Workaround

### DIFF
--- a/scripts/webpack.client.js
+++ b/scripts/webpack.client.js
@@ -7,7 +7,6 @@ module.exports = (dirname, file = 'client') => ({
   devtool: production ? false : 'source-map',
   entry: `./src/client/client.tsx`,
   output: {
-    hashFunction: "xxhash64",
     path: path.join(dirname, 'out'),
     filename: `${file}.bundle.js`,
     publicPath: 'http://localhost:8116/',

--- a/scripts/webpack.extension.js
+++ b/scripts/webpack.extension.js
@@ -7,7 +7,6 @@ module.exports = dirname => ({
   devtool: production ? false : 'source-map',
   entry: './src/extension.ts',
   output: {
-    hashFunction: "xxhash64",
     path: path.join(dirname, 'out'),
     filename: process.argv.includes('web') ? 'extension.web.js' : 'extension.js',
     libraryTarget: 'commonjs2',


### PR DESCRIPTION
As pointed out in https://github.com/godotengine/godot-csharp-vscode/pull/41, adding `hashFunction: 'xxhash64` doesn't seem to be necessary anymore for `webpack@5.70.0`.
Changes made in this PR will revert this workaround that was included in my previous PR #73.