### PR TITLE
Prevent TypeScript clearing output in watch

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -10,13 +10,14 @@
 		"declaration": false,
 		"sourceMap": true,
 		"strict": true,
-    "jsx": "react",
+		"jsx": "react",
 		"jsxFactory": "h",
 		"moduleResolution": "node",
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
 		"noUnusedParameters": true,
-		"esModuleInterop": true
+		"esModuleInterop": true,
+		"preserveWatchOutput": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
This is particularly harmful as there are multiple watch tasks, so this could hide errors