### PR TITLE
Polish icon style with VS Code's find widget

### DIFF
--- a/packages/vscode-js-profile-core/src/client/toggle-button.css
+++ b/packages/vscode-js-profile-core/src/client/toggle-button.css
@@ -4,13 +4,13 @@
   display: flex;
   align-items: center;
   border: 1px solid transparent;
-  opacity: 0.7;
   outline: 0 !important;
-  margin-left: 3px;
-  margin-right: 3px;
-  padding: 3px;
+  margin-left: 2px;
+  margin-right: 2px;
+  padding: 1px;
   cursor: pointer;
-  color: var(--vscode-icon-foreground);
+  color: var(--vscode-editorWidget-foreground);
+  border-radius: 3px;
 }
 
 .button + .button {
@@ -18,15 +18,16 @@
 }
 
 .button:hover {
-  opacity: 1;
+  background-color: var(--vscode-inputOption-hoverBackground);
 }
 
 .button[aria-checked='true'] {
-  background: var(--vscode-inputOption-activeBackground);
+  background: var(--vscode-inputOption-activeBackground) !important;
+  color: var(--vscode-inputOption-activeForeground);
   border: 1px solid var(--vscode-inputOption-activeBorder);
-  opacity: 1;
 }
 
 .button > svg {
+  width: 16px;
   height: 16px;
 }

--- a/packages/vscode-js-profile-core/src/client/toggle-button.css
+++ b/packages/vscode-js-profile-core/src/client/toggle-button.css
@@ -28,5 +28,5 @@
 }
 
 .button > svg {
-  width: 1em;
+  height: 16px;
 }


### PR DESCRIPTION
Fixes #91

Left previous
Right icon rendered in terminal tab (SPAA is due to icon font, not SVG)

<img width="177" alt="image" src="https://user-images.githubusercontent.com/2193314/197357012-e957e85e-de5d-473f-88c9-8676ed33be47.png">

Editor find widget uses editor widget foreground: https://github.com/microsoft/vscode/blob/012cfb2795b4874c7e520ef0b43f92d0b0866dcf/src/vs/editor/contrib/find/browser/findWidget.ts#L1426-L1429

Before

![Recording 2022-10-22 at 07 48 26](https://user-images.githubusercontent.com/2193314/197357024-d4a9a7d9-4eaa-48ef-a86a-6c39449269bb.gif)

After
<img width="387" alt="image" src="https://user-images.githubusercontent.com/2193314/197357028-3fe26d3e-04b4-4341-a57a-787694e2944e.png">
