### PR TITLE
Align filter styling with the find widget

### DIFF
--- a/packages/vscode-js-profile-core/src/client/filter.css
+++ b/packages/vscode-js-profile-core/src/client/filter.css
@@ -1,10 +1,10 @@
 .wrapper {
-  background: var(--vscode-editor-background);
+  background: var(--vscode-input-background);
   flex-grow: 1;
   display: flex;
   align-items: center;
   border: 1px solid transparent;
-  background: var(--vscode-input-background);
+  border-radius: 2px;
 }
 
 .wrapper:focus-within {

--- a/packages/vscode-js-profile-core/src/client/rich-filter.css
+++ b/packages/vscode-js-profile-core/src/client/rich-filter.css
@@ -1,4 +1,9 @@
 .f {
   display: flex;
   align-items: center;
+  background: var(--vscode-editorWidget-background);
+  box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
+  height: 33px;
+  padding: 4px;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
Fixes #90

Before

<img width="416" alt="image" src="https://user-images.githubusercontent.com/2193314/197357060-2ea5c7c0-3dac-4fa9-88e2-38ef6fa80317.png">

After

<img width="625" alt="image" src="https://user-images.githubusercontent.com/2193314/197357067-09a22b45-7821-4df6-a3f5-39d96644618c.png">
