### PR TITLE
Synchronize rendering of all canvas components

### DIFF
--- a/packages/vscode-js-profile-flame/src/client/common/base-flame.tsx
+++ b/packages/vscode-js-profile-flame/src/client/common/base-flame.tsx
@@ -148,48 +148,50 @@ const makeBaseFlame = <T extends IHeapProfileNode | ILocation>(): FunctionCompon
       return;
     }
 
-    webContext.clearRect(0, Constants.TimelineHeight, canvasSize.width, canvasSize.height);
-    webContext.save();
-    webContext.beginPath();
-    webContext.rect(0, Constants.TimelineHeight, canvasSize.width, canvasSize.height);
+    requestAnimationFrame(() => {
+      webContext.clearRect(0, Constants.TimelineHeight, canvasSize.width, canvasSize.height);
+      webContext.save();
+      webContext.beginPath();
+      webContext.rect(0, Constants.TimelineHeight, canvasSize.width, canvasSize.height);
+      webContext.clip();
 
-    for (const box of rawBoxes.boxById.values()) {
-      if (box.y2 < bounds.y) {
-        continue;
+      for (const box of rawBoxes.boxById.values()) {
+        if (box.y2 < bounds.y) {
+          continue;
+        }
+
+        if (box.y1 > bounds.y + canvasSize.height) {
+          continue;
+        }
+
+        const xScale = canvasSize.width / (bounds.maxX - bounds.minX);
+        const x1 = Math.max(0, (box.x1 - bounds.minX) * xScale);
+        if (x1 > canvasSize.width) {
+          continue;
+        }
+
+        const x2 = (box.x2 - bounds.minX) * xScale;
+        if (x2 < 0) {
+          continue;
+        }
+
+        const width = x2 - x1;
+        if (width < 10) {
+          continue;
+        }
+
+        textCache.drawText(
+          webContext,
+          box.text,
+          x1 + 3,
+          box.y1 - bounds.y + 3,
+          width - 6,
+          Constants.BoxHeight,
+        );
       }
 
-      if (box.y1 > bounds.y + canvasSize.height) {
-        continue;
-      }
-
-      const xScale = canvasSize.width / (bounds.maxX - bounds.minX);
-      const x1 = Math.max(0, (box.x1 - bounds.minX) * xScale);
-      if (x1 > canvasSize.width) {
-        continue;
-      }
-
-      const x2 = (box.x2 - bounds.minX) * xScale;
-      if (x2 < 0) {
-        continue;
-      }
-
-      const width = x2 - x1;
-      if (width < 10) {
-        continue;
-      }
-
-      textCache.drawText(
-        webContext,
-        box.text,
-        x1 + 3,
-        box.y1 - bounds.y + 3,
-        width - 6,
-        Constants.BoxHeight,
-      );
-    }
-
-    webContext.clip();
-    webContext.restore();
+      webContext.restore();
+    });
   }, [webContext, bounds, rawBoxes, canvasSize, cssVariables]);
 
   // Re-render the zoom indicator when bounds change

--- a/packages/vscode-js-profile-flame/src/client/common/webgl/boxes.ts
+++ b/packages/vscode-js-profile-flame/src/client/common/webgl/boxes.ts
@@ -136,23 +136,25 @@ export const setupGl = ({
     gl.vertexAttribPointer(boxAttributeLocation, 4, gl.FLOAT, false, 0, 0);
   };
 
+  let timeout: number;
+
   /**
    * Redraws the set of arrays on the screen.
    */
   const redraw = () => {
+    timeout = 0;
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexBuffer);
     gl.enableVertexAttribArray(boxAttributeLocation);
     gl.drawElements(gl.TRIANGLES, vertexCount, gl.UNSIGNED_INT, 0);
   };
 
-  let timeout: number;
   const debounceRedraw = () => {
     if (timeout) {
-      clearTimeout(timeout);
+      return;
     }
 
-    timeout = setTimeout(redraw, 2) as unknown as number;
+    timeout = requestAnimationFrame(redraw) as unknown as number;
   };
 
   const boundsLocation = gl.getUniformLocation(boxProgram, 'bounds');


### PR DESCRIPTION
This change does the following:

- Moves the webgl rendering from a timeout to an animation frame, this will reduce latency and support dropping frames is needed.
- Moves the text rendering to an animation frame, I'm not sure how the clip was working before but it needs to be called before the text is drawn.

Fixes #99

Before
![197341851-570f3fbe-7a1c-4aee-a940-80b8ce50f582](https://user-images.githubusercontent.com/2193314/197518035-b5351206-1899-491d-8d2e-b3db3d5465b7.gif)

After
![Recording 2022-10-23 at 08 22 04](https://user-images.githubusercontent.com/2193314/197518084-b07a83fd-580a-4cb6-aa9f-cdfc1d1fdd68.gif)

I also measured it with 6x CPU throttle but didn't save the gif apparently. The results were at expected; lots of dropped frames, but always in sync.
