### PR TITLE
Improve precision and timeline label spacing

### DIFF
--- a/packages/vscode-js-profile-flame/src/client/common/base-flame.tsx
+++ b/packages/vscode-js-profile-flame/src/client/common/base-flame.tsx
@@ -218,9 +218,6 @@ const makeBaseFlame = <T extends IHeapProfileNode | ILocation>(): FunctionCompon
     webContext.strokeStyle = cssVariables['editorRuler-foreground'];
     webContext.lineWidth = 1 / dpr;
 
-    // Timeline min spacing
-    // Timeline max spacing
-
     const labels = Math.round(canvasSize.width / Constants.TimelineLabelSpacing);
     const spacing = canvasSize.width / labels;
 

--- a/packages/vscode-js-profile-flame/src/client/common/constants.ts
+++ b/packages/vscode-js-profile-flame/src/client/common/constants.ts
@@ -7,7 +7,7 @@ export const enum Constants {
   TextColor = '#fff',
   BoxColor = '#000',
   TimelineHeight = 22,
-  TimelineLabelSpacing = 200,
+  TimelineLabelSpacing = 100,
   MinWindow = 0.005,
   ExtraYBuffer = 300,
   DefaultStackLimit = 7,


### PR DESCRIPTION
This reduces the timeline label spacing by 50% so more tiemstamps are shown and also adds a simple approach for showing precision as previously it would only work when looking at the very left side of the flame chart.

Ideally this would use a more sophisticated method of showing the lines at a round number and improving the precision to work at more intervals like .2ms, .5ms, 5ms, etc.

Fixes #100

---

Before
![Recording 2022-10-23 at 10 10 17](https://user-images.githubusercontent.com/2193314/197518342-143146bf-ab16-4e29-afb6-833fd7fec9c8.gif)

After
![Recording 2022-10-23 at 10 09 17](https://user-images.githubusercontent.com/2193314/197518366-af133786-fcfe-44d5-b260-f366beb5dc2e.gif)
