### PR TITLE
Improve call stack styling to align closer with debug

### DIFF
--- a/packages/vscode-js-profile-flame/src/client/common/common.css
+++ b/packages/vscode-js-profile-flame/src/client/common/common.css
@@ -7,3 +7,13 @@
   display: inline-block;
   cursor: pointer;
 }
+
+.lineNumber {
+  padding: 3px 4px;
+  border-radius: 11px;
+  font-size: 11px;
+  min-width: 18px;
+  min-height: 18px;
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}

--- a/packages/vscode-js-profile-flame/src/client/common/common.css
+++ b/packages/vscode-js-profile-flame/src/client/common/common.css
@@ -1,3 +1,7 @@
+.function {
+  font-family: var(--vscode-editor-font-family);
+}
+
 .goToFile {
   width: 1em;
   display: inline-block;

--- a/packages/vscode-js-profile-flame/src/client/common/flame-graph.css
+++ b/packages/vscode-js-profile-flame/src/client/common/flame-graph.css
@@ -96,6 +96,8 @@
   padding: 1rem;
   display: flex;
   align-items: flex-start;
+  flex: 0 0 auto;
+  overflow: hidden;
 }
 
 @media (max-width: 400px) {
@@ -125,21 +127,31 @@
 
 .info ol {
   padding-left: 1em;
+  overflow: hidden;
 }
 
 .info ol li {
-  word-break: break-all;
+  white-space: nowrap;
+  display: flex;
+  flex: 0 0 auto;
+  line-height: 1.5em;
 }
 
 .info ol li a {
   padding: 0.1em 0;
-  display: inline-block;
+  display: flex;
   cursor: pointer;
   color: var(--vscode-editor-foreground);
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .info ol li em {
   font-style: normal;
+  direction: rtl;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding-left: 2em;
 }
 
 .info ol li a em {

--- a/packages/vscode-js-profile-flame/src/client/common/stack-list.tsx
+++ b/packages/vscode-js-profile-flame/src/client/common/stack-list.tsx
@@ -84,9 +84,11 @@ const BoxLink: FunctionComponent<{ box: IBox; onClick(box: IBox): void; link?: b
 
   const click = useCallback(() => onClick(box), [box, onClick]);
   const locText = getNodeText(box.loc);
+  const lineCol = locText?.match(/:(\d+(:\d+)?)$/)?.[1];
+  const locFile = locText?.substring(0, locText.length - (lineCol ? lineCol.length + 1 : 0));
   const linkContent = (
     <Fragment>
-      <span className={styles.function}>{box.loc.callFrame.functionName}</span> <em title={locText}>{locText}</em>
+      <span className={styles.function}>{box.loc.callFrame.functionName}</span> <em title={locFile}>{locFile} <span className={styles.lineNumber}>{lineCol}</span></em>
     </Fragment>
   );
 

--- a/packages/vscode-js-profile-flame/src/client/common/stack-list.tsx
+++ b/packages/vscode-js-profile-flame/src/client/common/stack-list.tsx
@@ -86,7 +86,7 @@ const BoxLink: FunctionComponent<{ box: IBox; onClick(box: IBox): void; link?: b
   const locText = getNodeText(box.loc);
   const linkContent = (
     <Fragment>
-      {box.loc.callFrame.functionName} <em>({locText})</em>
+      <span className={styles.function}>{box.loc.callFrame.functionName}</span> <em title={locText}>{locText}</em>
     </Fragment>
   );
 


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-js-profile-visualizer/issues/96
Part of #123 

Not fully done but it's a great improvement imo

Before
![image](https://user-images.githubusercontent.com/2193314/197518633-28f52372-0511-434c-b9a3-32468acc1452.png)

After
![image](https://user-images.githubusercontent.com/2193314/197518655-2aa5f790-d3fd-4c0f-8066-ff8442194078.png)

