### PR TITLE
Add metric for HeapTotal and Resident Set size

### DIFF
--- a/packages/vscode-js-profile-flame/src/realtime/metrics.ts
+++ b/packages/vscode-js-profile-flame/src/realtime/metrics.ts
@@ -144,6 +144,46 @@ export class ResidentSetMetric extends Metric {
   }
 }
 
+export class ExternalMetric extends Metric {
+  public update(timestamp: number, metrics: IDAMetrics): void {
+    if (metrics.memory /* node */) {
+      this.push(timestamp, metrics.memory.external);
+    }
+  }
+
+  public format(metric: number): string {
+    return formatSize(metric);
+  }
+
+  public short(): string {
+    return 'External';
+  }
+
+  public name(): string {
+    return 'External Memory';
+  }
+}
+
+export class ArrayBuffersMetric extends Metric {
+  public update(timestamp: number, metrics: IDAMetrics): void {
+    if (metrics.memory /* node */) {
+      this.push(timestamp, metrics.memory.arrayBuffers);
+    }
+  }
+
+  public format(metric: number): string {
+    return formatSize(metric);
+  }
+
+  public short(): string {
+    return 'ArrayBuffer';
+  }
+
+  public name(): string {
+    return 'ArrayBuffer Memory';
+  }
+}
+
 export class DOMNodes extends Metric {
   public update(timestamp: number, metrics: IDAMetrics): void {
     if (metrics.Nodes) {
@@ -209,6 +249,8 @@ export const createMetrics = () => [
   new HeapMetric(),
   new HeapTotalMetric(),
   new ResidentSetMetric(),
+  new ExternalMetric(),
+  new ArrayBuffersMetric(),
   new DOMNodes(),
   new LayoutCount(),
   new StyleRecalcs(),

--- a/packages/vscode-js-profile-flame/src/realtime/metrics.ts
+++ b/packages/vscode-js-profile-flame/src/realtime/metrics.ts
@@ -104,6 +104,46 @@ export class HeapMetric extends Metric {
   }
 }
 
+export class HeapTotalMetric extends Metric {
+  public update(timestamp: number, metrics: IDAMetrics): void {
+    if (metrics.memory /* node */) {
+      this.push(timestamp, metrics.memory.heapTotal);
+    }
+  }
+
+  public format(metric: number): string {
+    return formatSize(metric);
+  }
+
+  public short(): string {
+    return 'Heap Total';
+  }
+
+  public name(): string {
+    return 'Heap Total';
+  }
+}
+
+export class ResidentSetMetric extends Metric {
+  public update(timestamp: number, metrics: IDAMetrics): void {
+    if (metrics.memory /* node */) {
+      this.push(timestamp, metrics.memory.rss);
+    }
+  }
+
+  public format(metric: number): string {
+    return formatSize(metric);
+  }
+
+  public short(): string {
+    return 'RSS';
+  }
+
+  public name(): string {
+    return 'Resident Set Size';
+  }
+}
+
 export class DOMNodes extends Metric {
   public update(timestamp: number, metrics: IDAMetrics): void {
     if (metrics.Nodes) {
@@ -167,6 +207,8 @@ export class StyleRecalcs extends DerivativeMetric {
 export const createMetrics = () => [
   new CpuMetric(),
   new HeapMetric(),
+  new HeapTotalMetric(),
+  new ResidentSetMetric(),
   new DOMNodes(),
   new LayoutCount(),
   new StyleRecalcs(),


### PR DESCRIPTION
Hey, hope you're doing well, I'm back with a follow-up to #63. While investigating reports of memory leaks in Next.js we found that this time it wasn't realted to the `heapUsed` but instead `rss` increasing and that couldn't be observed with this extension. So I came to the realization that all memory metrics should be reported as the data is there already and then you can opt-in/out of which one you want to observe.
