### PR TITLE
fix: missing colors in flame chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9311,7 +9311,7 @@
       }
     },
     "packages/vscode-js-profile-flame": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@vscode/codicons": "^0.0.30",

--- a/packages/vscode-js-profile-flame/package-lock.json
+++ b/packages/vscode-js-profile-flame/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-js-profile-flame",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-js-profile-flame",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.30",

--- a/packages/vscode-js-profile-flame/package.json
+++ b/packages/vscode-js-profile-flame/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-js-profile-flame",
   "displayName": "Flame Chart Visualizer for JavaScript Profiles",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Flame graph visualizer for Heap and CPU profiles taken from the JavaScript debugger",
   "author": "Connor Peet <connor@peet.io>",
   "homepage": "https://github.com/microsoft/vscode-js-profile-visualizer#readme",

--- a/packages/vscode-js-profile-flame/src/client/common/webgl/boxes.ts
+++ b/packages/vscode-js-profile-flame/src/client/common/webgl/boxes.ts
@@ -172,6 +172,8 @@ export const setupGl = ({
   };
 
   const setFocusColor = (color: string) => {
+    color = color.trim();
+
     if (!chroma.valid(color)) {
       return;
     }
@@ -182,6 +184,8 @@ export const setupGl = ({
   };
 
   const setPrimaryColor = (color: string) => {
+    color = color.trim();
+
     if (!chroma.valid(color)) {
       return;
     }


### PR DESCRIPTION
Trim whitespace that prevents chroma from parsing the color