### PR TITLE
Support virtual filesystems Fixes #154

### DIFF
--- a/packages/vscode-js-profile-core/src/open-location.ts
+++ b/packages/vscode-js-profile-core/src/open-location.ts
@@ -68,8 +68,8 @@ const runIfCommand = async (location: ISourceLocation) => {
     const params = !uri.query
       ? baseparams
       : uri.query.split('&').reduce((acc, param) => {
-          const [name, value] = param.split('=');
-          return { ...acc, [name]: decodeURIComponent(value) };
+          const [name] = param.split('=',1);
+          return { ...acc, [name]: decodeURIComponent(param.replace(/[^=]+=/, "")) };
         }, baseparams);
     await vscode.commands.executeCommand(uri.path, params); // delegate finding the position to the command provider
     return true;


### PR DESCRIPTION
I basically added 2 features, logically distinct who boil down to the same concept of custom URL schema support in location URLs:

- support for virtual filesystems (i.e. "adt:a4s/foo","js-viz-download:/foo/bar" )
- support for command URLs (i.e. "command:myextension.mycommand?par1=foo&par2=bar")

The 1st is for any virtual filesystem, like i.e. [ssh fs](https://marketplace.visualstudio.com/items?itemName=Kelvin.vscode-sshfs) or [Abap FS](), current implementation tested  with explicit schemas in location URLs, implicit ones might work as is or require replacing path and fs functions in `getCandidateDiskPaths` with vscode awere alternatives

The 2nd is for my specific use case: resolving URLs is expensive, so by encoding vscode commands as URLs I can do that only when the user clicks on them. It's a [standard vscode feature](https://code.visualstudio.com/api/extension-guides/command), not tied to my extension
